### PR TITLE
Removed six requirement

### DIFF
--- a/game.py
+++ b/game.py
@@ -3,7 +3,6 @@ import os
 import sys
 import time
 
-import six
 from termcolor import colored
 
 from core import World
@@ -102,7 +101,10 @@ class Game(object):
             self.draw()
 
             if self.debug:
-                six.moves.input()
+                if sys.version_info > (3,):
+                    input()
+                else:
+                    raw_input()
             else:
                 time.sleep(1.0 / frames_per_second)
 

--- a/players/me.py
+++ b/players/me.py
@@ -1,5 +1,5 @@
 #coding: utf-8
-import six
+import sys
 
 from things import Player, Zombie
 from utils import closest
@@ -14,7 +14,10 @@ class Me(Player):
         print('j: attack closest zombie')
         print('k: heal self')
         print('l: heal closest player')
-        action = six.moves.input()
+        if sys.version_info > (3,):
+            action = input()
+        else:
+            action = raw_input()
 
         if not action:
             self.status = 'sitting idle'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 termcolor
 docopt
-six


### PR DESCRIPTION
Got rid of six, since we were only using it for `six.moves.input()`
