### PR TITLE
Add bound checks

### DIFF
--- a/core.py
+++ b/core.py
@@ -142,6 +142,8 @@ class World(object):
             event = u'hit %s with his head' % obstacle.name
         elif distance(thing.position, destination) > 1:
             event = u'tried to walk too fast, but physics forbade it'
+        elif not(0 <= destination[0] <= self.size[0] and 0 <= destination[1] <= self.size[1]):
+            event = u'tried to move out of bounds'
         else:
             # we store position in the things, because they need to know it,
             # but also in our dict, for faster access


### PR DESCRIPTION
# PR Content

This PR adds bound checks before move in `things_move`

Without this bound check, zombies may move outside map bounds.

out of bounds often takes place during: `python play.py extermination troll,troll -z 300 -m fort`